### PR TITLE
Add runnable code examples

### DIFF
--- a/problem-space/0002-string-interop.md
+++ b/problem-space/0002-string-interop.md
@@ -27,37 +27,65 @@ However, maintaining consistent semantics across all string operations is challe
 ### Example Code
 [example-code]: #example-code
 
-This Rust code passes a read-only Rust string pointer to C++:
+This example is similar to the one in [the unique ownership problem statement](0004-unique-ownership.md), but it uses pointers to avoid undefined behaviour.
+
+The Rust code passes some Rust `CStr` pointers to C++.
+The C++ code constructs larger `std::string`s by copying their data bytes from the Rust pointer into a new allocation, which is an unacceptable performance trade-off for some use cases.
 
 ```rust
-use std::ffi::CStr;
+#![recursion_limit = "256"]
+
+use cpp::cpp;
+use std::ffi::c_char;
+
+fn main() {
+    unsafe {
+        pass_strings_to_cplusplus(c"a".as_ptr(), c"not small string optimized".as_ptr());
+    }
+}
 
 unsafe extern "C" {
-    fn use_string_in_cplusplus(pointer: *const u8, length: usize);
+    fn pass_strings_to_cplusplus(cstr: *const c_char, cother: *const c_char);
 }
 
-unsafe fn pass_string_to_cplusplus(cstr: &'static CStr) {
-    let length = cstr.count_bytes();
-    let pointer = cstr.as_ptr();
-    // SAFETY:
-    // - The pointer must not be read after Rust has deallocated or moved the string, or beyond `length + 1` (the `nul` byte).
-    // - The pointer must never be written to.
-    unsafe { use_string_in_cplusplus(pointer, length); };
+cpp! {{
+    #include <string>
+    #include <cstring>
+    #include <iostream>
+
+    extern "C" {
+        extern const size_t SIZE_OF_CPP_STRING;
+
+        void use_strings_in_rust(const std::basic_string<char> *cppstr, const std::basic_string<char> *other);
+    }
+
+    extern "C" void pass_strings_to_cplusplus(const char *cstr, const char *cother) {
+        auto cppstr = std::string(cstr, strlen(cstr));
+        auto other = std::string(cother, strlen(cother));
+
+        // Required for FFI safety by Rust (fails at compile time)
+        //static_assert(std::is_trivially_move_constructible_v<typeof(cppstr)>);
+        if (SIZE_OF_CPP_STRING != sizeof(cppstr)) { std::cout << "Size is " << SIZE_OF_CPP_STRING << " in Rust but " << sizeof(cppstr) << " in C++" << std::endl; abort(); }
+
+        use_strings_in_rust(&cppstr, &other);
+    }
+}}
+
+#[unsafe(no_mangle)]
+static SIZE_OF_CPP_STRING: usize = 24;
+
+#[repr(C)]
+struct CppString {
+    data: [u8; SIZE_OF_CPP_STRING],
+}
+
+#[unsafe(no_mangle)]
+unsafe fn use_strings_in_rust(cppstr: *const CppString, other: *const CppString) {
+    println!("{cppstr:?}, {other:?}")
 }
 ```
 
-The C++ code constructs a `std::string` by copying `length` bytes from the Rust pointer into a new allocation, which is an unacceptable performance trade-off for some use cases:
-
-```c++
-#include <cstdint>
-#include <string>
-
-void use_string_in_cplusplus(const uint8_t* pointer, size_t length) {
-    auto cppstr = std::string((const char *)pointer, length);
-
-    // do_something_with(cppstr);
-}
-```
+This code can be run using the [`cpp` crate](https://docs.rs/cpp/latest/cpp/macro.cpp.html), like the [Build and Run code example](https://github.com/rustfoundation/interop-initiative/issues/5).
 
 ## Related Problems
 [related-problems]: #related-problems

--- a/problem-space/0003-type-layout.md
+++ b/problem-space/0003-type-layout.md
@@ -16,46 +16,69 @@ Mismatching layouts can lead to unsoundness, if data is not marshalled using the
 ### Example Code
 [example-code]: #example-code
 
-This Rust code passes a read-only Rust struct to C++:
+This Rust code passes a read-only Rust struct to C++.
+
+The C++ code has its own definition of the struct, which must be kept ABI-compatible with the Rust struct `Example`.
+This is particularly tricky in the presence of non-standard types, such as floating point and 128-bit integers.
 
 ```rust
+use cpp::cpp;
+
 #[repr(C)]
+#[derive(Debug)]
 struct Example {
     byte: u8,
     fractional: f32,
     integer: u128,
 }
 
-unsafe extern "C" {
-    fn use_struct_in_cplusplus(pointer: *const Example);
+fn main() {
+    let ex = Example {
+        byte: 42,
+        fractional: 3.5,
+        integer: 9000,
+    };
+    println!("{ex:?}");
+    unsafe {
+        pass_struct_to_cplusplus(&ex);
+    }
 }
 
-unsafe fn pass_struct_to_cplusplus(example: &'static Example) {
-    let pointer =std::ptr::from_ref(example);
+unsafe fn pass_struct_to_cplusplus(ex: &Example) {
+    let ex_ptr = std::ptr::from_ref(ex);
     // SAFETY:
     // - The pointer must not be read after Rust has deallocated or moved the struct, or beyond the size of the struct.
     // - The pointer must never be written to.
-    unsafe { use_struct_in_cplusplus(pointer); };
+    unsafe {
+        use_struct_in_cplusplus(ex_ptr);
+    };
 }
+
+unsafe extern "C" {
+    fn use_struct_in_cplusplus(ex_ptr: *const Example);
+}
+
+cpp! {{
+    #include <iostream>
+    #include <cstdint>
+    //#include <boost/cstdfloat.hpp>
+    namespace boost {
+        typedef float float32_t;
+    }
+
+    typedef struct {
+        uint8_t byte;
+        boost::float32_t fractional;
+        __uint128_t integer;
+    } example_t;
+
+    extern "C" void use_struct_in_cplusplus(const example_t* ex_ptr) {
+        std::cout << "Example: " << ex_ptr->byte << ", " << ex_ptr->fractional << ", " << (unsigned long long)ex_ptr->integer << std::endl;
+    }
+}}
 ```
 
-The C++ code has its own definition of the struct, which must be kept ABI-compatible with the Rust struct `Example`.
-This is particularly tricky in the presence of non-standard types, such as floating point and 128-bit integers.
-
-```c++
-#include <cstdint>
-#include <boost/cstdfloat.hpp>
-
-typedef struct {
-    uint8_t byte;
-    boost::float32_t fractional,
-    __uint128_t integer;
-} example_t;
-
-void use_struct_in_cplusplus(const example_t* pointer) {
-    // do_something_with(pointer);
-}
-```
+This code can be run using the [`cpp` crate](https://docs.rs/cpp/latest/cpp/macro.cpp.html), like the [Build and Run code example](https://github.com/rustfoundation/interop-initiative/issues/5).
 
 See also the "Layout issues" section of [RFC 3845](https://github.com/rust-lang/rfcs/pull/3845/changes), which has multiple platform-specific Rust/C layout compatibility code examples.
 

--- a/problem-space/0004-unique-ownership.md
+++ b/problem-space/0004-unique-ownership.md
@@ -22,43 +22,62 @@ Some users might benefit from custom move operation support in Rust.
 ### Example Code
 [example-code]: #example-code
 
-This C++ code passes a read-write C++ string object to Rust:
-
-```c++
-#include <string>
-#include <cstring>
-#include <cassert>
-
-extern "C" {
-    extern const size_t SIZE_OF_CPP_STRING;
-
-    void use_string_in_rust(std::basic_string<char> cppstr);
-}
-
-void pass_string_to_rust(const char *cstr) {
-    auto cppstr = std::string(cstr, strlen(cstr));
-
-    // Required for FFI safety by Rust, but fails at compile time
-    //static_assert(std::is_trivially_move_constructible_v<typeof(cppstr)>);
-    assert(sizeof(cppstr) == SIZE_OF_CPP_STRING);
-
-    use_string_in_rust(cppstr);
-}
-```
-
-But as soon as Rust moves the C++ string, it is undefined behaviour:
+This C++ code passes some read-write C++ string objects to Rust.
+But as soon as Rust moves the C++ strings, it is undefined behaviour, because `string` is not trivially relocatable.
 
 ```rust
-static SIZE_OF_CPP_STRING: usize = 32;
+#![recursion_limit = "256"]
+
+use cpp::cpp;
+use std::ffi::c_char;
+
+fn main() {
+    unsafe {
+        pass_strings_to_cplusplus(c"a".as_ptr(), c"not small string optimized".as_ptr());
+    }
+}
+
+unsafe extern "C" {
+    fn pass_strings_to_cplusplus(cstr: *const c_char, cother: *const c_char);
+}
+
+cpp! {{
+    #include <string>
+    #include <cstring>
+    #include <iostream>
+
+    extern "C" {
+        extern const size_t SIZE_OF_CPP_STRING;
+
+        void swap_strings_in_rust(std::basic_string<char> *cppstr, std::basic_string<char> *other);
+    }
+
+    extern "C" void pass_strings_to_cplusplus(const char *cstr, const char *cother) {
+        auto cppstr = std::string(cstr, strlen(cstr));
+        auto other = std::string(cother, strlen(cother));
+
+        // Required for FFI safety by Rust (fails at compile time)
+        //static_assert(std::is_trivially_move_constructible_v<typeof(cppstr)>);
+        if (SIZE_OF_CPP_STRING != sizeof(cppstr)) { std::cout << "Size is " << SIZE_OF_CPP_STRING << " in Rust but " << sizeof(cppstr) << " in C++" << std::endl; abort(); }
+
+        std::cout << cppstr << " | " << &cppstr << " | " << (void *)cppstr.c_str() << ", " << other << " | " << &other << " | " << (void *)other.c_str() << " before" << std::endl;
+        swap_strings_in_rust(&cppstr, &other);
+        std::cout << cppstr << " | " << &cppstr << " | " << (void *)cppstr.c_str() << ", " << other << " | " << &other << " | " << (void *)other.c_str() << " after" << std::endl;
+    }
+}}
+
+#[unsafe(no_mangle)]
+static SIZE_OF_CPP_STRING: usize = 24;
 
 #[repr(C)]
 struct CppString {
     data: [u8; SIZE_OF_CPP_STRING],
 }
 
-unsafe fn use_string_in_rust(cppstr: CppString) {
+#[unsafe(no_mangle)]
+unsafe fn swap_strings_in_rust(cppstr: &mut CppString, other: &mut CppString) {
     // Undefined behaviour: `string` is not trivially move constructible in C++
-    let moved_cppstr = cppstr;
+    std::mem::swap(cppstr, other);
 }
 ```
 

--- a/problem-space/0008-lossless-integer-roundtrip.md
+++ b/problem-space/0008-lossless-integer-roundtrip.md
@@ -64,6 +64,52 @@ The following C/C++ integer types have no corresponding Rust type:
 | bool               | size is implementation-defined                       |
 | unsigned field:{N} | Only compatible with u{N} for N = 8, 16, 32, 64, 128 |
 
+#### Interop Platform Differences
+[interop-platform-differences]: #interop-platform-differences
+
+This self-contained runnable example demonstrates how [C integer platform differences](https://stackoverflow.com/questions/384502/what-is-the-bit-size-of-long-on-64-bit-windows) can cause Rust compilation failures:
+
+```rust
+use std::ffi::{c_long, c_uint};
+use cpp::cpp;
+
+fn main() {
+    let count: u32 = u32::MAX;
+    println!("{count}: Hello, Rust u32!");
+    #[allow(clippy::useless_conversion, reason = "only needed on Windows 64-bit")]
+    let count: i64 = unsafe { native_cplusplus_integers(count) }.into();
+    println!("{count}: Hello, Interop platform differences!");
+}
+
+unsafe extern "C" {
+    fn native_cplusplus_integers(count: c_uint) -> c_long;
+}
+
+cpp! {{
+    #include <iostream>
+
+    extern "C" long send_rust_foreign_types(unsigned int count);
+
+    extern "C" long native_cplusplus_integers(unsigned int count) {
+        count--;
+        std::cout << count << ": Hello C++ silent integer conversion!" << std::endl;
+        send_rust_foreign_types(count);
+        // Silently truncates on Windows
+        return count;
+    }
+}}
+
+#[unsafe(no_mangle)]
+extern "C" fn send_rust_foreign_types(mut count: c_uint) -> c_long {
+    count -= 1;
+    println!("{count}: Hello, Rust inner c_uint!");
+    // Compilation fails on Windows 64-bit: u64 to i64
+    count.into()
+}
+```
+
+This code can be run using the [`cpp` crate](https://docs.rs/cpp/latest/cpp/macro.cpp.html), like the [Build and Run code example](https://github.com/rustfoundation/interop-initiative/issues/5).
+
 ## Related Problems
 [related-problems]: #related-problems
 


### PR DESCRIPTION
This PR adds an integer interop code example, and updates the code examples for type layout, ownership, and strings so they are easily runnable.

I'll work on vectors and allocators tomorrow, I think class inheritance might be tricky to make code examples for.