### PR TITLE
Add a floating point use case to integer round trips

### DIFF
--- a/problem-space/0008-lossless-integer-roundtrip.md
+++ b/problem-space/0008-lossless-integer-roundtrip.md
@@ -7,13 +7,15 @@
 ## Summary
 [summary]: #summary
 
-Rust and C++ have different integer types. Some of these integer types have equivalents in the other language, but a few don't.
+Rust and C++ have different integer and floating point types. Some of these types have equivalents in the other language, but a few don't.
 
-Many interop users would benefit from lossless roundtrips between Rust and C++. This might also improve performance in hot, integer-heavy code.
+Many interop users would benefit from lossless roundtrips between Rust and C++. This might also improve performance in hot, integer- or float-heavy code.
 
-Other interop users would benefit from [a 1:1 mapping](https://github.com/google/crubit/blob/main/support/ffi_11/src/lib.rs) between Rust and C++ integer types, [to support C++ templates and overloads](https://hackmd.io/uZ8hHkYXQQCLtwuS7xP6JQ?view#Integer-Types).
+Other interop users would benefit from [a 1:1 mapping](https://github.com/google/crubit/blob/main/support/ffi_11/src/lib.rs) between Rust and C++ integer and float types, [to support C++ templates and overloads](https://hackmd.io/uZ8hHkYXQQCLtwuS7xP6JQ?view#Integer-Types).
 
-Rust's FFI integer types are based on the most popular C compiler (and compiler settings) on each architecture, which causes challenges for less popular compilers and non-standard settings.
+Rust's FFI integer and float types are based on the most popular C compiler (and compiler settings) on each architecture, which causes challenges for less popular compilers and non-standard settings.
+
+It also causes issues with [type promotion of variadic arguments](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Is.20varargs.20f32.20.60float.60.20or.20.60_Float32.60/near/585803988), inckuding floating point.
 
 In Rust, the set of conversions available with `Into` is a subset of lossless `as` casts.
 The `as` operator can also silently perform lossy casts in Rust, but there are `clippy` lints that:
@@ -146,6 +148,7 @@ Solutions should handle (or explain why handling these types isn't needed):
 
 - Rust's `std::ffi` uses `i8` for [`c_char`](https://doc.rust-lang.org/stable/std/ffi/type.c_char.html), but Crubit uses [`u8`](https://docs.rs/ffi_11/latest/ffi_11/struct.c_char.html)
 - Requiring C++ `uint8_t` to be `unsigned char` (?)
+- [Variadic argument promotion of floating point types](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Is.20varargs.20f32.20.60float.60.20or.20.60_Float32.60/near/585803988)
 - TODO: add extra examples here
 
 On Windows:

--- a/problem-space/0008-lossless-integer-roundtrip.md
+++ b/problem-space/0008-lossless-integer-roundtrip.md
@@ -15,7 +15,7 @@ Other interop users would benefit from [a 1:1 mapping](https://github.com/google
 
 Rust's FFI integer and float types are based on the most popular C compiler (and compiler settings) on each architecture, which causes challenges for less popular compilers and non-standard settings.
 
-It also causes issues with [type promotion of variadic arguments](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Is.20varargs.20f32.20.60float.60.20or.20.60_Float32.60/near/585803988), inckuding floating point.
+It also causes issues with [type promotion of variadic arguments in C/C++](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Is.20varargs.20f32.20.60float.60.20or.20.60_Float32.60/near/585803988), inckuding floating point.
 
 In Rust, the set of conversions available with `Into` is a subset of lossless `as` casts.
 The `as` operator can also silently perform lossy casts in Rust, but there are `clippy` lints that:
@@ -148,7 +148,7 @@ Solutions should handle (or explain why handling these types isn't needed):
 
 - Rust's `std::ffi` uses `i8` for [`c_char`](https://doc.rust-lang.org/stable/std/ffi/type.c_char.html), but Crubit uses [`u8`](https://docs.rs/ffi_11/latest/ffi_11/struct.c_char.html)
 - Requiring C++ `uint8_t` to be `unsigned char` (?)
-- [Variadic argument promotion of floating point types](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Is.20varargs.20f32.20.60float.60.20or.20.60_Float32.60/near/585803988)
+- [Variadic argument promotion of C/C++ floating point types](https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Is.20varargs.20f32.20.60float.60.20or.20.60_Float32.60/near/585803988)
 - TODO: add extra examples here
 
 On Windows:


### PR DESCRIPTION
Turns out float round trips matter too, see this discussion:
https://rust-lang.zulipchat.com/#narrow/channel/213817-t-lang/topic/Is.20varargs.20f32.20.60float.60.20or.20.60_Float32.60/near/585803874